### PR TITLE
Extend the database choice to support MySQL Community Edition RDBMS

### DIFF
--- a/HOWTOs/Install/InstallApplicationHowTo.md
+++ b/HOWTOs/Install/InstallApplicationHowTo.md
@@ -15,17 +15,20 @@ This HOWTO describes the installation and initial configuration of the Stroom Ap
 The following command will ensure the prerequisite software has been deployed
 
 ```bash
-sudo yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel policycoreutils-python unzip zip mariadb
+sudo yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel policycoreutils-python unzip zip
+sudo yum -y install mariadb
+or
+sudo yum -y install mysql-community-client
 ```
 
 ## Test Database connectivity
 We need to test access to the Stroom database server - `stroomdb0.strmdev00.org`. We do this using the client `mysql` utility. We note that we
-must enter the _stroomuser_ user's password set up in the creation of the database earlier (`stroompassword1`).
+must enter the _stroomuser_ user's password set up in the creation of the database earlier (`Stroompassword1@`).
 
 Our test connects to the database and sets the default database to be the `stroom` database.
 ```
 [root@stroomp00 tmp]# mysql --user=stroomuser --host=stroomdb0.strmdev00.org -p
-Enter password: <__ stroompassword1 __>
+Enter password: <__ Stroompassword1@ __>
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 2
 Server version: 5.5.52-MariaDB MariaDB Server
@@ -40,6 +43,29 @@ MariaDB [stroom]> exit
 Bye
 [root@stroomp00 tmp]# 
 ```
+In the case of a MySQL Community deployment you will see
+```
+[root@stroomp00 tmp]# mysql --user=stroomuser --host=stroomdb0.strmdev00.org -p
+Enter password: 
+Welcome to the MySQL monitor.  Commands end with ; or \g.
+Your MySQL connection id is 7
+Server version: 5.7.17 MySQL Community Server (GPL)
+
+Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+
+Oracle is a registered trademark of Oracle Corporation and/or its
+affiliates. Other names may be trademarks of their respective
+owners.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+mysql> use stroom;
+Database changed
+mysql> exit
+Bye
+[root@stroomp00 tmp]# 
+```
+
 If there are any errors, correct them.
 
 ## Get the Software
@@ -69,7 +95,7 @@ PORT_PREFIX should use the default, just press return
 JDBC_CLASSNAME should use the default, just press return
 JDBC_URL to 'jdbc:mysql://stroomdb0.strmdev00.org/stroom?useUnicode=yes&characterEncoding=UTF-8'
 DB_USERNAME should be our processing user, 'stroomuser'
-DB_PASSWORD should be the one we set when creating the stroom database, that is 'stroompassword1'
+DB_PASSWORD should be the one we set when creating the stroom database, that is 'Stroompassword1@'
 JPA_DIALECT should use the default, just press return
 JAVA_OPTS can use the defaults, but ensure you have sufficient memory, either change or accept the default
 STATS_ENGINES should use the default, just press return

--- a/HOWTOs/Install/InstallHowTo.md
+++ b/HOWTOs/Install/InstallHowTo.md
@@ -100,10 +100,23 @@ The core software list is
 Most of the required software are packages available via standard repositories and hence we can simply execute
 ```bash
 sudo yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel policycoreutils-python unzip zip
+```
+
+One has a choice of database clients. MariaDB is directly supported by Centos 7 and is simplest to install. This is done via
+```bash
 sudo yum -y install mariadb
 ```
-In the above instance, the database client choice is MariaDB as it is directly supported by Centos 7. One could deploy the MySQL
-database software as the alternative.
+
+One could deploy the MySQL database software as the alternative.
+
+<a name="mysqlclientinstall"></a>To do this you need to install the MySQL Community repository files then install the client. 
+Instructions for installation of the MySQL Community repository files can be
+found [here](InstallDataBaseHowTo.md#mysql-community-repository-installation "MySQL Community Repository Installation") or on
+the [MySQL Site](https://dev.mysql.com/downloads/repo/yum "Download MySQL Yum Repository").
+Once you have installed the MySQL repository files, install the client via
+```bash
+sudo yum -y install mysql-community-client
+```
 
 Note that additional software will be required for other integration components (e.g. Apache httpd/mod_jk). This is
 described in the [Web Service Integration](#web-service-integration "Web Service Integration") section of this document.
@@ -561,10 +574,10 @@ Connect to the Stroom database as the administrative (root) user, via the comman
 sudo mysql --user=root -p
 ```
 
-and at the `MariaDB [(none)]>` prompt enter
+and at the `MariaDB [(none)]>` or `mysql> ` prompt enter
 
 ```bash
-grant all privileges on stroom.* to stroomuser@stroomp02.strmdev00.org identified by 'stroompassword1';
+grant all privileges on stroom.* to stroomuser@stroomp02.strmdev00.org identified by 'Stroompassword1@';
 quit;
 ```
 
@@ -586,7 +599,7 @@ sudo yum -y install mariadb
 ```
 In the above instance, the database client choice is MariaDB as it is directly supported by Centos 7. One could deploy the MySQL
 database software as the alternative. If you have chosen a different database for the already deployed Stroom Cluster then you
-should use that one.
+should use that one. See [earlier](#mysqlclientinstall) in this document on how to install the MySQL Community client.
 
 Note that additional software will be required for other integration components (e.g. Apache httpd/mod_jk). This is
 described in the [Web Service Integration](#web-service-integration "Web Service Integration") section of this document.

--- a/HOWTOs/Install/InstallHowTo.md
+++ b/HOWTOs/Install/InstallHowTo.md
@@ -111,7 +111,7 @@ One could deploy the MySQL database software as the alternative.
 
 <a name="mysqlclientinstall"></a>To do this you need to install the MySQL Community repository files then install the client. 
 Instructions for installation of the MySQL Community repository files can be
-found [here](InstallDataBaseHowTo.md#mysql-community-repository-installation "MySQL Community Repository Installation") or on
+found [here](InstallDatabaseHowTo.md#mysql-community-repository-installation "MySQL Community Repository Installation") or on
 the [MySQL Site](https://dev.mysql.com/downloads/repo/yum "Download MySQL Yum Repository").
 Once you have installed the MySQL repository files, install the client via
 ```bash

--- a/HOWTOs/Install/InstallProxyHowTo.md
+++ b/HOWTOs/Install/InstallProxyHowTo.md
@@ -18,9 +18,11 @@ The following command will ensure the prerequisite software has been deployed
 ```bash
 sudo yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel policycoreutils-python unzip zip
 sudo yum -y install mariadb
+or
+sudo yum -y install mysql-community-client
 ```
 
-Note that we do __NOT__ need the Mariadb client software for a Forwarding or Standalone proxy.
+Note that we do __NOT__ need the database client software for a Forwarding or Standalone proxy.
 
 ## Get the Software
 The following will gain the identified, in this case release `5.1-beta.3`, Stroom Application software release from github, then deploy it. You should regularly monitor the site for newer releases.
@@ -66,7 +68,7 @@ REPO_DIR should be set to '/stroomdata/stroom-working-p00/proxy' or '/stroomdata
 JDBC_CLASSNAME should use the default, just press return
 JDBC_URL should be set to 'jdbc:mysql://stroomdb0.strmdev00.org/stroom'
 DB_USERNAME should be our processing user, 'stroomuser'
-DB_PASSWORD should be the one we set when creating the stroom database, that is 'stroompassword1'
+DB_PASSWORD should be the one we set when creating the stroom database, that is 'Stroompassword1@'
 JAVA_OPTS can use the defaults, but ensure you have sufficient memory, either change or accept the default
 ```
 


### PR DESCRIPTION
The HOWTO documentation has been updated to include support for using the MySQL Community Edition RDBMS rather than MariaDB.
Aside from the software installation changes, as MySQL 5.7 imposes more strict password choices, the example `stroomuser` password has changed.

Further, the Stroom Systemd service scripts have changed. There are now two choices, one for a Stroom Processing or Proxy node and the other for a Stroom Processing or Proxy node with a database on the same node.