### PR TITLE
Cater for Stroom statistics database installation

### DIFF
--- a/HOWTOs/Install/InstallCertificatesHowTo.md
+++ b/HOWTOs/Install/InstallCertificatesHowTo.md
@@ -136,6 +136,7 @@ mv stroom-jks.tar /stroomdata/stroom-data-p01
 ```
 then on the another node, say `stroomp01.strmdev00.org`, as the stroomuser we extract the data.
 ```bash
+sudo -i -u stroomuser
 cd ~stroomuser
 tar xf /stroomdata/stroom-data-p01/stroom-jks.tar && rm -f /stroomdata/stroom-data-p01/stroom-jks.tar
 ```

--- a/HOWTOs/Install/InstallDatabaseHowTo.md
+++ b/HOWTOs/Install/InstallDatabaseHowTo.md
@@ -1,25 +1,31 @@
 # Stroom HOWTO - Database Installation
-This HOWTO describes the installation of a Stroom database. Following this HOWTO will produce a simple, minimally secured database deployment.
-In a production environment consideration needs to be made for redundancy, better security, data-store location, increased memory usage, and the like.
+This HOWTO describes the installation of the Stroom databases. Following this HOWTO will produce a simple, minimally secured database deployment. In a production environment consideration needs to be made for redundancy, better security, data-store location, increased memory usage, and the like.
+
+Stroom has two databases. The first, `stroom`, is used for management of Stroom itself and the second, `statistics` is used for the Stroom Statistics capability. There are many ways to deploy these two databases. One could
+- have a single database instance and serve both databases from it
+- have two database instances on the same server and serve one database per instance
+- have two separate nodes, each with it's own database instance
+- the list goes on.
+
+In this HOWTO, we describe the deployment of two database instances on the one node, each serving a single database. We provide example deployments using either the [MariaDB](https://mariadb.com "MariaDB Site") or [MySQL Community](https://www.mysql.com/products/community/ "MySQL Community Site") versions of MySQL.
 
 ## Assumptions
-- we are installing the MariaDB or MySQL Community RDBMS software
+- we are installing the MariaDB or MySQL Community RDBMS software.
 - the primary database node is 'stroomdb0.strmdev00.org'.
 - installation is on a fully patched minimal Centos 7.3 instance.
+- we are installing BOTH databases (`stroom` and `statistics`) on the same node - 'stroomdb0.stromdev00.org' but with two distinct database engines. The first database will communicate on port `3307` and the second on `3308`.
+- we are deploying with SELinux in enforcing mode.
 - any scripts or commands that should run are in code blocks and are designed to allow the user to cut then paste the commands onto their systems.
 - in this document, when a textual screen capture is documented, data entry is identified by the data surrounded by '<__' '__>' . This excludes enter/return presses.
 
 ## Installation of Software
 ### MariaDB Server Installation
-As MariaDB is directly supported by Centos 7, we simply install the database server software, then enable and start it's service as per
+As MariaDB is directly supported by Centos 7, we simply install the database server software and SELinux policy files, as per
 ```bash
-sudo yum -y install mariadb mariadb-server
-sudo systemctl enable mariadb.service
-sudo systemctl start mariadb.service
+sudo yum -y install policycoreutils-python mariadb-server
 ```
-### MySQL Community
-#### MySQL Community Repository Installation
-As MySQL is not directly supported by Centos 7, we need to install it's repository files prior to installation. 
+### MySQL Community Server Installation
+As MySQL is not directly supported by Centos 7, we need to install it's repository files prior to installation.
 We get the current MySQL Community release repository rpm and validate it's MD5 checksum against the published value found on the
 [MySQL Yum Repository](https://dev.mysql.com/downloads/repo/yum "Download MySQL Yum Repository") site.
 ```bash
@@ -32,20 +38,135 @@ On correct validation of the MD5 checksum, we install the repository files via
 sudo yum -y localinstall mysql57-community-release-el7.rpm
 ```
 
-#### MySQL Community Server Installation
-Next we install server software, then enable and start it's service as per
+Next we install server software and SELinux policy files, as per
 ```bash
-sudo yum -y install mysql-community-client mysql-community-server
-sudo systemctl enable mysqld.service
-sudo systemctl start mysqld.service
+sudo yum -y install policycoreutils-python mysql-community-server
 ```
 
-## Securing the Database
-### MariaDB
-We secure the database engine by running the `mysql_secure_installation` script. One should accept all defaults, which means the
-only entry (aside from pressing returns) is the administrator (root) database password. Make a note of the password you use.
+## Preparing the Database Deployment
+### MariaDB Variant
+#### Create and instantiate both database instances
+To set up two MariaDB database instances on the one node, we will use `mysql_multi` and systemd service templates. The `mysql_multi` utility is a capability that manages multiple MariaDB databases on the same node and systemd service templates manage multiple services from one configuration file.  A systemd service template is unique in that it has an `@` character before the `.service` suffix.
+
+To use this multiple-instance capability, we need to create two data directories for each database instance and also replace the main MariaDB configuration file, `/etc/my.cnf`, with one that includes configuration of key options for each instance. We will name our instances, `mysqld0` and `mysqld1`. We will also create specific log files for each instance.
+
+We will use the directories, `/var/lib/mysql-mysqld0` and `/var/lib/mysql-mysqld1` for the data directories and `/var/log/mariadb/mysql-mysqld0.log` and `/var/log/mariadb/mysql-mysqld1.log` for the log files. Note you should modify /etc/logrotate.d/mariadb to manage these log files. Note also, we need to set the appropriate SELinux file contexts on the created directories and any files.
+
+We create the data directories and log files and set their respective SELinux contexts via
+```bash
+sudo mkdir /var/lib/mysql-mysqld0
+sudo chown mysql:mysql /var/lib/mysql-mysqld0
+sudo semanage fcontext -a -t mysqld_db_t "/var/lib/mysql-mysqld0(/.*)?"
+sudo restorecon -Rv /var/lib/mysql-mysqld0
+
+sudo touch /var/log/mariadb/mysql-mysqld0.log
+sudo chown mysql:mysql /var/log/mariadb/mysql-mysqld0.log
+sudo chcon --reference=/var/log/mariadb/mariadb.log /var/log/mariadb/mysql-mysqld0.log
+
+sudo mkdir /var/lib/mysql-mysqld1
+sudo chown mysql:mysql /var/lib/mysql-mysqld1
+sudo semanage fcontext -a -t mysqld_db_t "/var/lib/mysql-mysqld1(/.*)?"
+sudo restorecon -Rv /var/lib/mysql-mysqld1
+
+sudo touch /var/log/mariadb/mysql-mysqld1.log
+sudo chown mysql:mysql /var/log/mariadb/mysql-mysqld1.log
+sudo chcon --reference=/var/log/mariadb/mariadb.log /var/log/mariadb/mysql-mysqld1.log
+```
+
+We now initialise the our two database data directories via
+```bash
+sudo mysql_install_db --user=mysql --datadir=/var/lib/mysql-mysqld0
+sudo mysql_install_db --user=mysql --datadir=/var/lib/mysql-mysqld1
+```
+
+We now replace the  MySQL configuration file to set the options for each instance. Note that we will serve `mysqld0` and `mysqld1` via TCP ports `3307` and `3308` respectively. First backup the existing configuration file with
+```bash
+sudo cp /etc/my.cnf /etc/my.cnf.ORIG
+```
+then setup `/etc/my.cnf` as per
 
 ```bash
+sudo bash
+F=/etc/my.cnf
+printf '[mysqld_multi]\n' > ${F}
+printf 'mysqld = /usr/bin/mysqld_safe --basedir=/usr\n' >> ${F}
+printf '\n' >> ${F}
+printf '[mysqld0]\n' >> ${F}
+printf 'port=3307\n' >> ${F}
+printf 'mysqld = /usr/bin/mysqld_safe --basedir=/usr\n' >> ${F}
+printf 'datadir=/var/lib/mysql-mysqld0/\n' >> ${F}
+printf 'socket=/var/lib/mysql-mysqld0/mysql.sock\n' >> ${F}
+printf 'pid-file=/var/run/mariadb/mysql-mysqld0.pid\n' >> ${F}
+printf '\n' >> ${F}
+printf 'log-error=/var/log/mariadb/mysql-mysqld0.log\n' >> ${F}
+printf '\n' >> ${F}
+printf '# Disabling symbolic-links is recommended to prevent assorted security\n' >> ${F}
+printf '# risks\n' >> ${F}
+printf 'symbolic-links=0\n' >> ${F}
+printf '\n' >> ${F}
+printf '[mysqld1]\n' >> ${F}
+printf 'mysqld = /usr/bin/mysqld_safe --basedir=/usr\n' >> ${F}
+printf 'port=3308\n' >> ${F}
+printf 'datadir=/var/lib/mysql-mysqld1/\n' >> ${F}
+printf 'socket=/var/lib/mysql-mysqld1/mysql.sock\n' >> ${F}
+printf 'pid-file=/var/run/mariadb/mysql-mysqld1.pid\n' >> ${F}
+printf '\n' >> ${F}
+printf 'log-error=/var/log/mariadb/mysql-mysqld1.log\n' >> ${F}
+printf '\n' >> ${F}
+printf '# Disabling symbolic-links is recommended to prevent assorted security risks\n' >> ${F}
+printf 'symbolic-links=0\n' >> ${F}
+exit # To exit the root shell
+```
+We also need to associate the ports with the `mysqld_port_t` SELinux context as per
+```bash
+sudo semanage port -a -t mysqld_port_t -p tcp 3307
+sudo semanage port -a -t mysqld_port_t -p tcp 3308
+```
+We next create the systemd service template as per
+```bash
+sudo bash
+F=/etc/systemd/system/mysqld@.service
+
+printf '# Install in /etc/systemd/system\n' > ${F}
+printf '# Enable via systemctl enable mysqld@0 or systemctl enable mysqld@1\n' >> ${F}
+printf '[Unit]\n' >> ${F}
+printf 'Description=MySQL Multi Server for instance %%i\n' >> ${F}
+printf 'After=syslog.target\n' >> ${F}
+printf 'After=network.target\n' >> ${F}
+printf '\n' >> ${F}
+printf '[Service]\n' >> ${F}
+printf 'User=mysql\n' >> ${F}
+printf 'Group=mysql\n' >> ${F}
+printf 'Type=forking\n' >> ${F}
+printf 'ExecStart=/usr/bin/mysqld_multi start %%i\n' >> ${F}
+printf 'ExecStop=/usr/bin/mysqld_multi stop %%i\n' >> ${F}
+printf 'Restart=always\n' >> ${F}
+printf 'PrivateTmp=true\n' >> ${F}
+printf '\n' >> ${F}
+printf '[Install]\n' >> ${F}
+printf 'WantedBy=multi-user.target\n' >> ${F}
+chmod 644 ${F}
+exit; # to exit the root shell
+```
+
+We next enable and start both instances via
+```bash
+sudo systemctl enable mysqld@0
+sudo systemctl enable mysqld@1
+sudo systemctl start mysqld@0
+sudo systemctl start mysqld@1
+```
+At this we should have both instances running. One should check each instance's log file for any errors.
+
+#### Secure each database instance
+We secure each database engine by running the `mysql_secure_installation` script. One should accept all defaults, which means the
+only entry (aside from pressing returns) is the administrator (root) database password. Make a note of the password you use.
+The utility `mysql_secure_installation` expects to find the Linux socket file to access the database it's securing at `/var/lib/mysql/mysql.sock`.
+Since we have used other locations, we temporarily link the real socket file to `/var/lib/mysql/mysql.sock` for each invocation of the
+utility. Thus we execute
+
+```bash
+sudo ln /var/lib/mysql-mysqld0/mysql.sock /var/lib/mysql/mysql.sock
 sudo mysql_secure_installation
 ```
 to see
@@ -91,16 +212,16 @@ By default, MariaDB comes with a database named 'test' that anyone can
 access.  This is also intended only for testing, and should be removed
 before moving into a production environment.
 
-Remove test database and access to it? [Y/n] 
+Remove test database and access to it? [Y/n]
  - Dropping test database...
  ... Success!
  - Removing privileges on test database...
  ... Success!
- 
+
 Reloading the privilege tables will ensure that all changes made so far
 will take effect immediately.
 
-Reload privilege tables now? [Y/n] 
+Reload privilege tables now? [Y/n]
 ... Success!
 
 Cleaning up...
@@ -110,20 +231,94 @@ installation should now be secure.
 
 Thanks for using MariaDB!
 ```
-
-### MySQL Community
-There is no need to run the (traditional) `mysql_secure_installation` script for MySQL 5.7 versions or beyond, as the function of the program
-has already been performed by the yum repository installation.
-That said, the initial start up of the mysqld service will have created the administrator (root) account and set it's password.
-To reveal the password, run
+then we execute
 ```bash
-sudo grep 'temporary password' /var/log/mysqld.log
+sudo rm /var/lib/mysql/mysql.sock
+sudo ln /var/lib/mysql-mysqld1/mysql.sock /var/lib/mysql/mysql.sock
+sudo mysql_secure_installation
+sudo rm /var/lib/mysql/mysql.sock
 ```
-You should now reset the password. Note that MySQL 5.7 implements the validate_password plugin, so you will need a password that contains
-at least one upper case letter, one lower case letter, one digit, and one special character, and that the total password length is at least
-8 characters. Change the password via the following, using the password gained from the `/var/log/mysqld.log` above to authenticate to the mysql service.
+and process as before (for when running mysql_secure_installation). At this both database instances should be secure.
+
+### MySQL Community Variant
+#### Create and instantiate both database instances
+As of MySQL 5.7.13, on platforms for which systemd support is installed (i.e. Centos 7.3), systemd has the capability of managing multiple MySQL instances. We will make use of this facility.
+
+To use this multiple-instance capability, we need to create two data directories for each database instance and also modify the MySQL configuration file, `/etc/my.cnf`, to include configuration of key options for each instance. We will name our instances, `mysqld0` and `mysqld1`. We will also create specific log files for each instance.
+
+We will use the directories, `/var/lib/mysql-mysqld0` and `/var/lib/mysql-mysqld1` for the data directories and `/var/log/mysql-mysqld0.log` and `/var/log/mysql-mysqld1.log` for the log directories. Note you should modify /etc/logrotate.d/mysql to manage these log files. Note also, we need to set the appropriate SELinux file context on the created directories and files.
+
 ```bash
-mysql -uroot -p
+sudo mkdir /var/lib/mysql-mysqld0
+sudo chown mysql:mysql /var/lib/mysql-mysqld0
+sudo semanage fcontext -a -t mysqld_db_t "/var/lib/mysql-mysqld0(/.*)?"
+sudo restorecon -Rv /var/lib/mysql-mysqld0
+
+sudo touch /var/log/mysql-mysqld0.log
+sudo chown mysql:mysql /var/log/mysql-mysqld0.log
+sudo chcon --reference=/var/log/mysqld.log /var/log/mysql-mysqld0.log
+
+sudo mkdir /var/lib/mysql-mysqld1
+sudo chown mysql:mysql /var/lib/mysql-mysqld1 
+sudo semanage fcontext -a -t mysqld_db_t "/var/lib/mysql-mysqld1(/.*)?"
+sudo restorecon -Rv /var/lib/mysql-mysqld1
+
+sudo touch /var/log/mysql-mysqld1.log
+sudo chown mysql:mysql /var/log/mysql-mysqld1.log
+sudo chcon --reference=/var/log/mysqld.log /var/log/mysql-mysqld1.log
+```
+
+We now modify the  MySQL configuration file to set the options for each instance. Note that we will serve `mysqld0` and `mysqld1` via TCP ports `3307` and `3308` respectively.  First backup the existing configuration file with
+```bash
+sudo cp /etc/my.cnf /etc/my.cnf.ORIG
+```
+then setup `/etc/my.cnf` as per
+```bash
+sudo bash
+F=/etc/my.cnf
+printf '# Database for Stroom Application - stroom\n' >> ${F}
+printf '[mysqld@mysqld0]\n' >> ${F}
+printf 'datadir=/var/lib/mysql-mysqld0\n' >> ${F}
+printf 'socket=/var/lib/mysql-mysqld0/mysql.sock\n' >> ${F}
+printf 'port=3307\n' >> ${F}
+printf 'log-error=/var/log/mysql-mysqld0.log\n' >> ${F}
+printf '\n' >> ${F}
+printf '# Database for Stroom Statistics - statistics\n' >> ${F}
+printf '[mysqld@mysqld1]\n' >> ${F}
+printf 'datadir=/var/lib/mysql-mysqld1\n' >> ${F}
+printf 'socket=/var/lib/mysql-mysqld1/mysql.sock\n' >> ${F}
+printf 'port=3308\n' >> ${F}
+printf 'log-error=/var/log/mysql-mysqld1.log\n' >> ${F}
+exit # To exit the root shell
+```
+We also need to associate the ports with the `mysqld_port_t` SELinux context as per
+```bash
+sudo semanage port -a -t mysqld_port_t -p tcp 3307
+sudo semanage port -a -t mysqld_port_t -p tcp 3308
+```
+
+We next enable and start both instances via
+```bash
+sudo systemctl enable mysqld@mysqld0
+sudo systemctl enable mysqld@mysqld1
+sudo systemctl start mysqld@mysqld0
+sudo systemctl start mysqld@mysqld1
+```
+At this we should have both instances running. One should check each instance's log file for any errors.
+
+#### Secure each database instance
+There is no need to run the (traditional) `mysql_secure_installation` script for MySQL 5.7 versions or beyond, as the function of this program is effected the first time a database instance is started.
+That said, the initial start up of each mysqld service will have created the administrator (root) account and set it's password.
+To reveal the passwords, run
+```bash
+sudo grep 'temporary password' /var/log/mysql-mysqld0.log
+sudo grep 'temporary password' /var/log/mysql-mysqld1.log
+```
+You should now reset the passwords. Note that MySQL 5.7 implements the validate_password plugin, so you will need a password that contains
+at least one upper case letter, one lower case letter, one digit, and one special character, and that the total password length is at least
+8 characters. Change the password via the following, using the password gained from the logfiles above to authenticate to the mysql service. For `mysqld0`, run
+```bash
+mysql --user=root --port=3307 --socket=/var/lib/mysql-mysqld0/mysql.sock --password
 ```
 then entering the command
 ```sql
@@ -131,13 +326,13 @@ ALTER USER 'root'@'localhost' IDENTIFIED BY '<__ENTER_ROOT_DATABASE_PASSWORD__>'
 ```
 For example, we set the password to `Stroom5User@` as per 
 ```bash
-[burn@stroomdb0 ~]$ mysql -uroot -p
+[burn@stroomdb0 ~]$ mysql --user=root --port=3307 --socket=/var/lib/mysql-mysqld0/mysql.sock --password
 Enter password: < __ENTER_ROOT_DATABASE_PASSWORD_FROM_MYSQLD_LOG__>
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 4
-Server version: 5.7.17
+Server version: 5.7.18
 
-Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
 
 Oracle is a registered trademark of Oracle Corporation and/or its
 affiliates. Other names may be trademarks of their respective
@@ -152,60 +347,99 @@ mysql> quit
 Bye
 [burn@stroomdb0 ~]$
 ```
-
-## Create the Database
-Now we create the Stroom database and prepare to allow the processing user from each node to use it. Thus we execute
+and for the second instance, `mysqld1`, run
 ```bash
-sudo mysql --user=root -p
+mysql --user=root --port=3308 --socket=/var/lib/mysql-mysqld1/mysql.sock --password
 ```
+and set the password appropriately as for the first instance then exit.
 
-and on entering the administrator's password we arrive at the `MariaDB [(none)]> ` or `mysql> ` prompt.
-At this we create the database with
-```bash
-create database stroom;
-```
+## Create the Databases and Enable access by the Stroom processing users
+We now create the `stroom` database within the first instance, `mysqld0` and the `statistics` database within the second
+instance `mysqld1`. It does not matter which database variant used as all commands are the same for both.
 
-## Enable processing users to access the database
-Each Stroom processing node will need to access the database. We will use the database user `stroomuser` with a password
-of `stroompassword1` when granting access. One identifies the processing user as `<user>@<host>` on the `grant`
-SQL command. In the database instance below, we will grant access for
+As well as creating the databases, we also need to establish the Stroom processing users
+that the Stroom processing nodes will use to access each database.
+For the `stroom` database, we will use the database user `stroomuser` with a password of `Stroompassword1@` and for the `statistics` database, we will use the database user `stroomstats` with a password of `Stroompassword2@`. One identifies a processing user as `<user>@<host>` on a `grant` SQL command.
+
+In the `stroom` database instance, we will grant access for
 - stroomuser@localhost for local access for maintenance etc.
 - stroomuser@stroomp00.strmdev00.org for access by processing node stroomp00.strmdev00.org
 - stroomuser@stroomp01.strmdev00.org for access by processing node stroomp01.strmdev00.org
 
-Thus we execute
+and in the `statistics` database instance, we will grant access for
+
+- stroomstats@localhost for local access for maintenance etc.
+- stroomstats@stroomp00.strmdev00.org for access by processing node stroomp00.strmdev00.org
+- stroomstats@stroomp01.strmdev00.org for access by processing node stroomp01.strmdev00.org
+
+Thus for the `stroom` database we execute
 ```bash
+mysql --user=root --port=3307 --socket=/var/lib/mysql-mysqld0/mysql.sock --password
+```
+and on entering the administrator's password, we arrive at the `MariaDB [(none)]>` or `mysql>` prompt. At this we create the database with
+```sql
+create database stroom;
+```
+and then to establish the users, we execute
+```sql
 grant all privileges on stroom.* to stroomuser@localhost identified by 'Stroompassword1@';
 grant all privileges on stroom.* to stroomuser@stroomp00.strmdev00.org identified by 'Stroompassword1@';
 grant all privileges on stroom.* to stroomuser@stroomp01.strmdev00.org identified by 'Stroompassword1@';
 ```
-Clearly if we need to add more processing node, additional `grant` commands would be used. Further, if we were installing the database in a single node Stroom environment, we would just have the first two `grants`.
-
-To exit the `mysql` utility, execute
-```bash
-quit
+then
+```sql
+quit;
 ```
+to exit.
+
+And for the `statistics` database 
+```bash
+mysql --user=root --port=3308 --socket=/var/lib/mysql-mysqld1/mysql.sock --password
+```
+with
+```sql
+create database statistics;
+```
+and then to establish the users, we execute
+```sql
+grant all privileges on statistics.* to stroomstats@localhost identified by 'Stroompassword2@';
+grant all privileges on statistics.* to stroomstats@stroomp00.strmdev00.org identified by 'Stroompassword2@';
+grant all privileges on statistics.* to stroomstats@stroomp01.strmdev00.org identified by 'Stroompassword2@';
+```
+then
+```sql
+quit;
+```
+to exit.
+
+Clearly if we need to add more processing nodes, additional `grant` commands would be used. Further, if we were installing the databases in a single node Stroom environment, we would just have the first two pairs of `grants`.
 
 ## Configure Firewall
-Next we need to modify our firewall to allow remote access to our database which listens on port 3306 by default.
+Next we need to modify our firewall to allow remote access to our databases which listens on ports 3307 and 3308.
 The simplest way to achieve this is with the commands
 ```bash
-sudo firewall-cmd --zone=public --add-port=3306/tcp --permanent
+sudo firewall-cmd --zone=public --add-port=3307/tcp --permanent
+sudo firewall-cmd --zone=public --add-port=3308/tcp --permanent
 sudo firewall-cmd --reload
 sudo firewall-cmd --zone=public --list-all
 ```
-__Note__ that this allows ANY node to connect to your database. You should give consideration to restricting this to only allowing processing node access.
+__Note__ that this allows ANY node to connect to your databases. You should give consideration to restricting this to only allowing processing node access.
 
 ### Debugging of Mariadb for Stroom
-If there is a need to debug the Mariadb and Stroom interaction, on can turn on auditing for the Mariadb service.
-To do so, log onto the database as the administrative user as per
+If there is a need to debug the Mariadb database and Stroom interaction, one can turn on auditing for the Mariadb service.
+To do so, log onto the relevant database as the administrative user as per
 ```bash
-sudo mysql --user=root -p
+mysql --user=root --port=3307 --socket=/var/lib/mysql-mysqld0/mysql.sock --password
+or
+mysql --user=root --port=3308 --socket=/var/lib/mysql-mysqld1/mysql.sock --password
 ```
 and at the `MariaDB [(none)]> ` prompt enter
 
 ```bash
-install plugin server_audit SONAME 'server_audit.so';
+install plugin server_audit SONAME 'server_audit';
+set global server_audit_file_path='/var/log/mariadb/mysqld-mysqld0_server_audit.log';
+or
+set global server_audit_file_path='/var/log/mariadb/mysqld-mysqld1_server_audit.log';
 set global server_audit_logging=ON;
 set global server_audit_file_rotate_size=10485760;
 install plugin SQL_ERROR_LOG soname 'sql_errlog';
@@ -213,9 +447,9 @@ quit;
 ```
 
 The above will generate two log files, 
-- `/var/lib/mysql/server_audit.log` which records all commands the database runs. We have configured the log file will rotate at 10MB in size.
-- `/var/lib/mysql/sql_errors.log` which records all erroneous SQL commands. This log file will rotate at 10MB in size.
-Both files will, by default, generate up to 9 rotated files.
+- `/var/log/mariadb/mysqld-mysqld0_server_audit.log` or `/var/log/mariadb/mysqld-mysqld1_server_audit.log` which records all commands the respective databases run. We have configured the log file will rotate at 10MB in size.
+- `/var/lib/mysql-mysqld0/sql_errors.log` or `/var/lib/mysql-mysqld1/sql_errors.log` which records all erroneous SQL commands. This log file will rotate at 10MB in size. Note we cannot set this filename via the UI, but it will be appear in the data directory.
+All files will, by default, generate up to 9 rotated files.
 
 If you wish to rotate a log file manually, log into the database as the administrative user and execute either
 - `set global server_audit_file_rotate_now=1;` to rotate the audit log file

--- a/HOWTOs/Install/InstallDatabaseHowTo.md
+++ b/HOWTOs/Install/InstallDatabaseHowTo.md
@@ -454,3 +454,22 @@ All files will, by default, generate up to 9 rotated files.
 If you wish to rotate a log file manually, log into the database as the administrative user and execute either
 - `set global server_audit_file_rotate_now=1;` to rotate the audit log file
 - `set global sql_error_log_rotate=1;` to rotate the sql_errlog log file
+
+### Initial Database Access
+
+It should be noted that if you monitor the sql_errors.log log file on a new Stooom deployment, when the Stoom Application first starts, it's initial access to the `stroom` database will result in the following attempted sql statements.
+```sql
+2017-04-16 16:24:50 stroomuser[stroomuser] @ stroomp00.strmdev00.org [192.168.2.126] ERROR 1146: Table 'stroom.schema_version' doesn't exist : SELECT version FROM schema_version ORDER BY installed_rank DESC
+2017-04-16 16:24:50 stroomuser[stroomuser] @ stroomp00.strmdev00.org [192.168.2.126] ERROR 1146: Table 'stroom.STROOM_VER' doesn't exist : SELECT VER_MAJ, VER_MIN, VER_PAT FROM STROOM_VER ORDER BY VER_MAJ DESC, VER_MIN DESC, VER_PAT DESC LIMIT 1
+2017-04-16 16:24:50 stroomuser[stroomuser] @ stroomp00.strmdev00.org [192.168.2.126] ERROR 1146: Table 'stroom.FD' doesn't exist : SELECT ID FROM FD LIMIT 1
+2017-04-16 16:24:50 stroomuser[stroomuser] @ stroomp00.strmdev00.org [192.168.2.126] ERROR 1146: Table 'stroom.FEED' doesn't exist : SELECT ID FROM FEED LIMIT 1
+```
+
+After this access the application will realise the database does not exist and it will initialise the database.
+
+In the case of the `statistics` database you may note the following attempted access
+```sql
+2017-04-16 16:25:09 stroomstats[stroomstats] @ stroomp00.strmdev00.org [192.168.2.126] ERROR 1146: Table 'statistics.schema_version' doesn't exist : SELECT version FROM schema_version ORDER BY installed_rank DESC 
+```
+
+Again, at this point the application will initialise this database.

--- a/HOWTOs/Install/InstallHowTo.md
+++ b/HOWTOs/Install/InstallHowTo.md
@@ -123,7 +123,33 @@ described in the [Web Service Integration](#web-service-integration "Web Service
 
 Note also, that Standalone or Forwarding Stroom Proxy deployments do __NOT__ need a database client deployed.
 
-### Storage Scenario
+### Entropy Issues in Virtual environments
+Both the Stroom Application and Stroom Proxy currently run on Tomcat (Version 7) which relies on the Java SecureRandom class to provide
+random values for any generated session identifiers as well as other components. In some circumstances the Java runtime can be delayed if the entropy source that is
+used to initialise SecureRandom is short of entropy. The delay is caused by the Java runtime waiting on the blocking entropy souce
+/dev/random to have sufficient entropy. This quite often occurs in virtual environments were there are few sources that can contribute to 
+a system's entropy.
+
+To view the current available entropy on a Linux system, run the command
+```bash
+cat /proc/sys/kernel/random/entropy_avail
+```
+A reasonable value would be over 2000 and a poor value would be below a few hundred.
+
+If you are deploying Stroom onto systems with low available entropy, the start time for the Stroom Proxy can be as high as 5 minutes and for
+the Application as high as 15 minutes.
+
+One software based solution would be to install the [haveged](http://www.issihosts.com/haveged "Haveged Web Site") service that attempts to provide an easy-to-use, unpredictable random number generator based upon an adaptation of the HAVEGE algorithm.
+To install execute
+```bash
+yum -y install haveged
+systemctl enable haveged
+systemctl start haveged
+```
+
+For background reading in this matter, see [this reference](https://www.digitalocean.com/community/tutorials/how-to-setup-additional-entropy-for-cloud-servers-using-haveged "Haveged Entropy Service") or [this reference](https://wiki.apache.org/tomcat/HowTo/FasterStartUp#Entropy_Source "How do I make Tomcat startup faster?").
+
+## Storage Scenario
 For the purpose of this Installation HOWTO, the following sets up the storage hierarchy for a two node processing
 cluster. To share our __permanent data__ we will use NFS. Accept that the NFS deployment described here is very simple, and
 in a production deployment, a _lot_ more security controls should be used. Further, 

--- a/HOWTOs/Install/InstallHowTo.md
+++ b/HOWTOs/Install/InstallHowTo.md
@@ -81,10 +81,10 @@ to both our processing nodes. At this point we will then integrate a web service
 then perform the initial configuration of Stroom via the user interface.
 
 ## Database Installation
-The Stroom capability requires access to a MySQL/MariaDB database to persist application configuration and metadata.
-Instructions for installation of the Stroom database can be found [here](InstallDatabaseHowTo.md "Database Installation").
-Although these instructions describe the deployment of the database to it's own node, there is no reason why one can't
-just install it on the first (or only) Stroom node.
+The Stroom capability requires access to two MySQL/MariaDB databases. The first is for persisting application configuration and metadata information, and the second is for the Stroom Statistics capability.
+Instructions for installation of the Stroom databases can be found [here](InstallDatabaseHowTo.md "Database Installation").
+Although these instructions describe the deployment of the databases to their own node, there is no reason why one can't
+just install them both on the first (or only) Stroom node.
 
 ## Prerequisite Software Installation
 Certain software packages are required for either the Stroom Proxy or Stroom Application to run.
@@ -780,7 +780,7 @@ in our [Stroom Tasks HowTo](../General/TasksHowTo.md "Stroom Task HOWTO") shows 
 
 
 ## Testing our New Node Installation
-To complete the installation process we will test that our new node has succsesfully integrated into our cluster.
+To complete the installation process we will test that our new node has successfully integrated into our cluster.
 
 First we need to ensure we have restarted the Apache Httpd service (httpd.service) on the original nodes so that the new workers.properties
 configuration files take effect.

--- a/HOWTOs/Install/InstallProxyHowTo.md
+++ b/HOWTOs/Install/InstallProxyHowTo.md
@@ -3,13 +3,14 @@ This HOWTO describes the installation and configuration of the Stroom Proxy soft
 
 ## Assumptions
 The following assumptions are used in this document.
-- the user has reasonable RHEL/Centos System administration skills
+- the user has reasonable RHEL/Centos System administration skills.
 - installation is on a fully patched minimal Centos 7.3 instance.
-- the Stroom database has been created and resides on the host `stroomdb0.strmdev00.org`
-- the application user `stroomuser` has been created
-- the user is or has deployed the two node Stroom cluster described [here](InstallHowTo.md#storage-scenario "HOWTO Storage Scenario")
-- the user has set up the Stroom processing user as described [here](InstallProcessingUserSetupHowTo.md "Processing User Setup")
-- the prerequisite software has been installed
+- the Stroom database has been created and resides on the host `stroomdb0.strmdev00.org` listening on port 3307.
+- the Stroom database user is `stroomuser` with a password of `Stroompassword1@`.
+- the application user `stroomuser` has been created.
+- the user is or has deployed the two node Stroom cluster described [here](InstallHowTo.md#storage-scenario "HOWTO Storage Scenario").
+- the user has set up the Stroom processing user as described [here](InstallProcessingUserSetupHowTo.md "Processing User Setup").
+- the prerequisite software has been installed.
 - when a screen capture is documented, data entry is identified by the data surrounded by '<__' '__>' . This excludes enter/return presses.
 
 ## Confirm Prerequisite Software Installation
@@ -66,7 +67,7 @@ NODE to be the hostname (not FQDN) of your host (i.e. 'stroomp00' or 'stroomp01'
 PORT_PREFIX should use the default, just press return
 REPO_DIR should be set to '/stroomdata/stroom-working-p00/proxy' or '/stroomdata/stroom-working-p01/proxy' depending on the node we are installing on
 JDBC_CLASSNAME should use the default, just press return
-JDBC_URL should be set to 'jdbc:mysql://stroomdb0.strmdev00.org/stroom'
+JDBC_URL should be set to 'jdbc:mysql://stroomdb0.strmdev00.org:3307/stroom'
 DB_USERNAME should be our processing user, 'stroomuser'
 DB_PASSWORD should be the one we set when creating the stroom database, that is 'Stroompassword1@'
 JAVA_OPTS can use the defaults, but ensure you have sufficient memory, either change or accept the default

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ docker run --name stroom-db -e MYSQL_ROOT_PASSWORD=my-secret-pw -e MYSQL_USER=st
 docker run -p 8080:8080 --link stroom-db -v ~/.stroom:/root/.stroom --name=stroom -e STROOM_JDBC_DRIVER_URL="jdbc:mysql://stroom-db/stroom?useUnicode=yes&characterEncoding=UTF-8" -e STROOM_JDBC_DRIVER_USERNAME="stroomuser" -e STROOM_JDBC_DRIVER_PASSWORD="stroompassword1" gchq/stroom
 ```
 
+A series of HOWTO Recipes for various elements of Stroom can be found [here](HOWTOs/StroomHowTos.md "Stroom HOWTO Recipes")
 # Stroom
 
 Stroom is a data processing, storage and analysis platform. It is scalable - just add more CPUs / servers for greater throughput. It is suitable for processing high volume data such as system logs, to provide valuable insights into IT performance and usage.

--- a/install-guide/stroom-app-install.md
+++ b/install-guide/stroom-app-install.md
@@ -32,9 +32,10 @@ This script asks a series of questions about configuration parameters. These par
   **This name needs match the name used in your worker.properties (e.g. 'node1' in the case 'node1.my.org')** 
 * **RACK** - Used to group nodes together (so for example nodes near each other process near data)
 * **PORT_PREFIX** - By default Stroom will run on port 8080
-* **JDBC_CLASSNAME**, **JDBC URL**, **DB USERNAME**, **DB PASSWORD** - MySQL connection details
+* **JDBC_CLASSNAME**, **JDBC URL**, **DB USERNAME**, **DB PASSWORD** - MySQL connection details for the **stroom** database
 * **JPA DIALECT** - Leave blank to use MySQL
 * **JAVA OPTS** - By default this is '-Xms1g -Xmx8g'. Stroom performs better if you use most of the servers memory so change the maximum memory setting (Xmx) accordingly, e.g. -Xmx40g will use 40 GB.
+* **STROOM_STATISTICS_SQL_JDBC_CLASSNAME**, **STROOM_STATISTICS_SQL_JDBC URL**, **STROOM_STATISTICS_SQL_DB USERNAME**, **STROOM_STATISTICS_SQL_DB PASSWORD** - MySQL connection details for the **statistics** database
 
 ### Running 
 


### PR DESCRIPTION
With the introduction of Stroom release [v5.0-beta.17](https://github.com/gchq/stroom/releases/tag/v5.0-beta.17), the Stroom **statistics** database was incorporated. As a result, the Stroom Installation HOWTO's have been modified to cater for both Stroom databases.
Further,  a quick modification to the Stroom Application install guide was made referencing the new statistics database configuration parameters.

Lastly, a note and hyperlink has been made to the HOWTO's from the main Stroom documentation page.