### PR TITLE
gh-115 Upgrade Docsy for dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ are not recorded in here. Changes are in chronological order with the most
 recent at the top.
 
 
+* Upgrade Docsy to 0.10.0 and enable the light/dark colour mode menu.
+
 * Add `Analytic Rules` user guide section covering queries, execution schedules, notifications, detections, duplicate management, streaming and table builder.
 
 * Add `Reports` user guide section covering report settings, file types, AI summaries and delivery.

--- a/config.toml
+++ b/config.toml
@@ -59,10 +59,11 @@ latexDashes = true
 [languages]
   [languages.en]
     title = "Stroom"
-    description = "Stroom documentation, release notes, news and open source community information"
     languageName ="English"
     # Weight used for sorting.
     weight = 1
+    [languages.en.params]
+      description = "Stroom documentation, release notes, news and open source community information"
 
 [markup]
   [markup.goldmark]
@@ -245,7 +246,10 @@ latexDashes = true
   navbar_logo = true
   
   # Set to true to disable the About link in the site footer
-  footer_about_disable = true
+  footer_about_enable = false
+
+  # Allow visitors to select light, dark or automatic colour mode.
+  showLightDarkModeMenu = true
   
   # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
   # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.
@@ -314,10 +318,7 @@ latexDashes = true
   # replacements = "github.com/google/docsy -> ../../docsy"
   [module.hugoVersion]
     extended = true
-    min = "0.73.0"
+    min = "0.125.4"
   [[module.imports]]
     path = "github.com/google/docsy"
-    disable = false
-  [[module.imports]]
-    path = "github.com/google/docsy/dependencies"
     disable = false

--- a/container_build/docker_hugo/Dockerfile
+++ b/container_build/docker_hugo/Dockerfile
@@ -14,18 +14,17 @@
 # limitations under the License.
 #**********************************************************************
 
-FROM klakegg/hugo:0.95.0-ext-alpine@sha256:5bd78a81d105aa68c208f6d0acc3ad4b93d3a37d258a4dea041034e03c2cf8b8
-
-# The behaviour of shortcode commenting seems to have changed in 0.111.3.
-# Also this repo seems dead so should consider another
-#FROM klakegg/hugo:0.111.3-ext-alpine
+FROM hugomods/hugo:0.125.4@sha256:a2b2404f4404e9c13cd23be6d095ad86ac6f7d234d4cc5fe551cb05641038066
 
 # Run separately so docker can cache the layer to speed up image creation
 RUN true \
     && apk update \
     && apk add --no-cache \
         bash \
-        git
+        git \
+    && npm install --global \
+        autoprefixer@9.8.6 \
+        postcss-cli@7.1.2
 
 # Work from the shared git repo dir
 WORKDIR /builder/shared

--- a/content/en/docs/user-guide/indexing/lucene.md
+++ b/content/en/docs/user-guide/indexing/lucene.md
@@ -38,7 +38,7 @@ Complete this page.
 ### Stored Fields
 
 If a field is _Stored_ then it means the complete field value will be stored in the index.
-This means the value can be retrieved from the index when building search results rather than using the slower [Search Extraction]({{< relref "extraction.md" >}}) process.
+This means the value can be retrieved from the index when building search results rather than using the slower [Search Extraction]({{< relref "docs/user-guide/search/search-extraction" >}}) process.
 Storing field values comes at the cost of high storage requirements for the index.
 If storage space is not an issue then storing all fields that you want to return in search results is the optimum.
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/gchq/stroom-docs
 
 go 1.17
 
-require github.com/google/docsy v0.6.0 // indirect
+require github.com/google/docsy v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,4 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20210804190922-7d3d774145ac/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.2.0 h1:DN6wfyyp2rXsjdV1K3wioxOBTRvG6Gg48wLPDso2lc4=
-github.com/google/docsy v0.2.0/go.mod h1:shlabwAQakGX6qpXU6Iv/b/SilpHRd7d+xqtZQd3v+8=
-github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=
-github.com/google/docsy v0.6.0/go.mod h1:VKKLqD8PQ7AglJc98yBorATfW7GrNVsn0kGXVYF6G+M=
-github.com/google/docsy/dependencies v0.2.0/go.mod h1:2zZxHF+2qvkyXhLZtsbnqMotxMukJXLaf8fAZER48oo=
-github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
-github.com/twbs/bootstrap v4.6.1+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
-github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.10.0 h1:6tMDacPwAyRWNCfvsn/9qGOZDQ8b0aRzjRZvnZPY5dg=
+github.com/google/docsy v0.10.0/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
+github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,36 +1,24 @@
-<!-- 
-  This is a modified copy of themes/docsy/layouts/partials/scripts.html
-  to add in conditions based on .Site.Params.offline_site
--->
-{{ if .Site.Params.offline_site }}
-<script src='{{ "/js/popper.min.js" | relURL }}'></script>
-<script src='{{ "/js/bootstrap.min.js" | relURL }}'></script>
-{{ else }}
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"
-    integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN"
-    crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.min.js"
-    integrity="sha512-UR25UO94eTnCVwjbXozyeVd6ZqpaAE9naiEUBK/A+QDbfSTQFhPGj5lOR6d8tsgbBk84Ggb5A3EkjsOgPRPcKA=="
-    crossorigin="anonymous"></script>
-{{ end }}
-
-{{ if .Site.Params.mermaid.enable }}
-<script src="https://cdn.jsdelivr.net/npm/mermaid@8.13.4/dist/mermaid.min.js" integrity="sha512-JERecFUBbsm75UpkVheAuDOE8NdHjQBrPACfEQYPwvPG+fjgCpHAz1Jw2ci9EXmd3DdfiWth3O3CQvcfEg8gsA==" crossorigin="anonymous"></script>
-{{ end }}
-
-<!-- STROOM - This was moved here from head.html to delay its loading -->
-{{ if .Site.Params.offlineSearch -}}
-  {{ if .Site.Params.offline_site }}
-    <script src='{{ "/js/lunr.min.js" | relURL }}'></script>
-  {{ else }}
-    <script
-      src="https://unpkg.com/lunr@2.3.9/lunr.min.js"
-      integrity="sha384-203J0SNzyqHby3iU6hzvzltrWi/M41wOP5Gu+BiJMz5nwKykbkUx8Kp7iti0Lpli"
-      crossorigin="anonymous"></script>
-  {{ end }}
+<!-- Stroom: keep Lunr local for offline documentation builds. -->
+{{ if and .Site.Params.offlineSearch .Site.Params.offline_site -}}
+<script src='{{ "/js/lunr.min.js" | relURL }}'></script>
+{{ else if .Site.Params.offlineSearch -}}
+<script src="https://unpkg.com/lunr@2.3.9/lunr.min.js"
+  integrity="sha384-203J0SNzyqHby3iU6hzvzltrWi/M41wOP5Gu+BiJMz5nwKykbkUx8Kp7iti0Lpli"
+  crossorigin="anonymous"></script>
 {{ end -}}
 
-{{ if .Site.Params.markmap.enable }}
+{{ $needKaTeX  := or .Site.Params.katex.enable .Params.math .Params.chem -}}
+{{ $needmhchem := or .Site.Params.katex.mhchem.enable .Params.chem -}}
+{{ if ge hugo.Version "0.93.0" -}}
+  {{ $needKaTeX = or $needKaTeX (.Page.Store.Get "hasKaTeX") (.Page.Store.Get "hasmhchem") -}}
+  {{ $needmhchem = or $needmhchem (.Page.Store.Get "hasmhchem") -}}
+{{ else -}}
+  {{ if or $needKaTeX $needmhchem -}}
+    {{ warnf "Outdated Hugo version %s, consider upgrading to make full use of all theme features" hugo.Version  }}
+  {{ end -}}
+{{ end -}}
+
+{{ if .Site.Params.markmap.enable -}}
 <style>
 .markmap > svg {
   width: 100%;
@@ -39,59 +27,104 @@
 </style>
 <script>
 window.markmap = {
-  autoLoader: { manual: true },
+  autoLoader: {
+      manual: true,
+      onReady() {
+        const { autoLoader, builtInPlugins } = window.markmap;
+        autoLoader.transformPlugins = builtInPlugins.filter(plugin => plugin.name !== 'prism');
+      },
+  },
 };
 </script>
 <script src="https://cdn.jsdelivr.net/npm/markmap-autoloader"></script>
-{{ end }}
+{{ end -}}
 
-<script src='{{ "/js/tabpane-persist.js" | relURL }}'></script>
+{{ if .Site.Params.plantuml.enable -}}
+  <script src='{{ "js/deflate.js" | relURL }}'></script>
+{{ end -}}
 
-<!-- load the deflate.js for plantuml support -->
-{{ if .Site.Params.plantuml.enable }}
-<script src='{{ "/js/deflate.js" | relURL }}'></script>
-{{ end }}
+{{ if  $needKaTeX -}}
+{{/* load stylesheet and scripts for KaTeX support */ -}}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css"
+      integrity="sha512-r2+FkHzf1u0+SQbZOoIz2RxWOIWfdEzRuYybGjzKq18jG9zaSfEy9s3+jMqG/zPtRor/q4qaUCYQpmSjTw8M+g==" crossorigin="anonymous">
+  {{/* The loading of KaTeX is deferred to speed up page rendering */ -}}
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"
+        integrity="sha512-INps9zQ2GUEMCQD7xiZQbGUVnqnzEvlynVy6eqcTcHN4+aQiLo9/uaQqckDpdJ8Zm3M0QBs+Pktg4pz0kEklUg=="
+        crossorigin="anonymous">
+</script>
+  {{ if $needmhchem -}}
+  {{/* To add support for displaying chemical equations and physical units, load the mhchem extension: */ -}}
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/mhchem.min.js"
+        integrity="sha512-mxjNw/u1lIsFC09k/unscDRY3ofIYPVFbWkP8slrePcS36ht4d/OZ8rRu5yddB2uiqajhTcLD8+jupOWuYPebg=="
+        crossorigin="anonymous">
+</script>
+  {{ end -}}
+  {{/* To automatically render math in text elements, include the auto-render extension: */ -}}
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"
+       integrity="sha512-YJVxTjqttjsU3cSvaTRqsSl0wbRgZUNF+NGGCgto/MUbIvaLdXQzGTCQu4CvyJZbZctgflVB0PXw9LLmTWm5/w==" crossorigin="anonymous"
+       {{ printf "onload='renderMathInElement(%s, %s);'" (( $.Page.Site.Params.katex.html_dom_element | default "document.body" ) | safeJS ) ( printf "%s" ( $.Page.Site.Params.katex.options | jsonify )) | safeHTMLAttr }}>
+</script>
+{{ end -}}
 
-<!-- load stylesheet and scripts for KaTeX support -->
-{{ if .Site.Params.katex.enable }}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/katex.min.css"
-    integrity="sha512-vJqxkZ+Sugf/6WRlpcxN01qVfX/29hF6qc33eHF1va3NgoV+U+wCi+uTAsQ10sDoGyBxHLdaHvGwDlV3yVYboA==" crossorigin="anonymous">
-<!-- The loading of KaTeX is deferred to speed up page rendering -->
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/katex.min.js"
-    integrity="sha512-5ufNcHqOYgilGEHPfuRIQ5B/vDS1M8+UC+DESZ5CwVgGTg+b2Ol/15rYL/GiCWJ/Sx8oVo0FPFok1dPk8U9INQ=="
+{{ $jsBs := resources.Get "vendor/bootstrap/dist/js/bootstrap.bundle.js" -}}
+{{ $jsBase := resources.Get "js/base.js" -}}
+{{ $jsSearch := resources.Get "js/search.js" | resources.ExecuteAsTemplate "js/search.js" .Site.Home -}}
+{{ $jsMarkmap := resources.Get "js/markmap.js" | resources.ExecuteAsTemplate "js/markmap.js" . -}}
+{{ $jsPlantuml := resources.Get "js/plantuml.js" | resources.ExecuteAsTemplate "js/plantuml.js" . -}}
+{{ $jsDrawio := resources.Get "js/drawio.js" | resources.ExecuteAsTemplate "js/drawio.js" . -}}
+{{ if .Site.Params.offlineSearch -}}
+  {{ $jsSearch = resources.Get "js/offline-search.js" -}}
+{{ end -}}
+
+{{ $jsArray := slice $jsBs $jsBase $jsSearch $jsPlantuml $jsMarkmap $jsDrawio -}}
+
+{{ if .Page.Store.Get "hasmermaid" -}}
+{{- partial "scripts/mermaid.html" . -}}
+{{ end -}}
+
+{{ if .Site.Params.ui.showLightDarkModeMenu -}}
+  {{ $jsArray = $jsArray | append (resources.Get "js/dark-mode.js") -}}
+{{ end -}}
+
+{{ $js := $jsArray | resources.Concat "js/main.js" -}}
+{{ if hugo.IsProduction -}}
+  {{ $js := $js | minify | fingerprint -}}
+  <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous"></script>
+{{ else -}}
+  <script src="{{ $js.RelPermalink }}"></script>
+{{ end -}}
+
+{{ if .Site.Params.prism_syntax_highlighting -}}
+  <script src='{{ "js/prism.js" | relURL }}'></script>
+{{ else if ( not .Site.Params.disable_click2copy_chroma ) -}}
+  {{ $c2cJS := resources.Get "js/click-to-copy.js" -}}
+  {{ if hugo.IsProduction -}}
+    {{ $c2cJS = $c2cJS | minify | fingerprint -}}
+  {{ end -}}
+  <script defer src="{{ $c2cJS.RelPermalink }}" {{ with $c2cJS.Data.Integrity -}}
+    integrity="{{ . }}" {{ end -}}
     crossorigin="anonymous"></script>
-<!-- check whether support of mhchem is enabled in config.toml -->
-{{ if .Site.Params.katex.mhchem.enable }}
-<!-- To add support for displaying chemical equations and physical units, load the mhchem extension: -->
-<script defer src="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/contrib/mhchem.min.js"
-    integrity="sha512-HWb6LyQhO6UkmYLjdSblpgiOvvbdkoMRjln0POPhOVbZu3l4QdqwZnMJ/cuwKScU5pWARejB495TAAAz0WNsXQ=="
-    crossorigin="anonymous"></script>
-{{ end }}
-<!-- To automatically render math in text elements, include the auto-render extension: -->
-<script defer src='https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/contrib/auto-render.min.js'
-    integrity='sha512-ZA/RPrAo88DlwRnnoNVqKINnQNcWERzRK03PDaA4GIJiVZvGFIWQbdWCsUebMZfkWohnfngsDjXzU6PokO4jGw==' crossorigin='anonymous' 
-    {{ printf "onload='renderMathInElement(%s, %s);'" (( .Site.Params.katex.html_dom_element | default "document.body" ) | safeJS ) ( printf "%s" ( $.Site.Params.katex.options | jsonify )) | safeHTMLAttr }}></script>
-{{ end }}
+{{ end -}}
 
-{{ $jsBase := resources.Get "js/base.js" }}
-{{ $jsAnchor := resources.Get "js/anchor.js" }}
-{{ $jsSearch := resources.Get "js/search.js" | resources.ExecuteAsTemplate "js/search.js" .Site.Home }}
-{{ $jsMermaid := resources.Get "js/mermaid.js" | resources.ExecuteAsTemplate "js/mermaid.js" . }}
-{{ $jsMarkmap := resources.Get "js/markmap.js" | resources.ExecuteAsTemplate "js/markmap.js" . }}
-{{ $jsPlantuml := resources.Get "js/plantuml.js" | resources.ExecuteAsTemplate "js/plantuml.js" . }}
-{{ $jsDrawio := resources.Get "js/drawio.js" | resources.ExecuteAsTemplate "js/plantuml.js" .}}
-{{ if .Site.Params.offlineSearch }}
-{{ $jsSearch = resources.Get "js/offline-search.js" }}
-{{ end }}
-{{ $js := (slice $jsBase $jsAnchor $jsSearch $jsMermaid $jsPlantuml $jsMarkmap $jsDrawio) | resources.Concat "js/main.js" }}
-{{ if not hugo.IsProduction }}
-<script src="{{ $js.RelPermalink }}"></script>
-{{ else }}
-{{ $js := $js | minify | fingerprint }}
-<script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}" crossorigin="anonymous"></script>
-{{ end }}
-{{ if .Site.Params.prism_syntax_highlighting }}
-<!-- scripts for prism -->
-<script src='{{ "/js/prism.js" | relURL }}'></script>
-{{ end }}
-{{ partial "hooks/body-end.html" . }}
+{{ if and .Site.Params.search (isset .Site.Params.search "algolia") -}}
+  {{ template "algolia/scripts" .Site.Params.search.algolia -}}
+{{ end -}}
+<script src='{{ "js/tabpane-persist.js" | relURL }}'></script>
+{{ partial "hooks/body-end.html" . -}}
+
+{{ define "algolia/scripts" -}}
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3.6.0"
+  integrity="sha512-FtDaTWf3IS29TLuYzTPlytjGqcXkwrzG9ivq7xXElnOZeiYTbcIy/hwXAgrrRNnI0+PfN+WFz4/+4phhJmuS8Q=="
+  crossorigin="anonymous" ></script>
+<script type="text/javascript">
+const containers = ['#docsearch-0', '#docsearch-1'];
+for (let c of containers) {
+  docsearch({
+    container: c,
+    appId: {{ .appId | default "R2IYF7ETH7" }},
+    apiKey: {{ .apiKey | default "599cec31baffa4868cae4e79f180729b" }},
+    indexName: {{ .indexName | default "docsearch" }},
+  });
+}
+</script>
+{{ end -}}

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -22,7 +22,7 @@ Page resources
 {{ $image := .Page.Resources.GetMatch (printf "%s" (.Get 0)) }}
 {{ if not $image }}
   {{/* Image not in the page resources, so get from global assets/images */}}
-  {{ $path := printf "/images/%s" (.Get 0) }}
+  {{ $path := printf "images/%s" (.Get 0) }}
   {{/* printf "path: [%s]" $path */}}
   {{ $image = resources.Get (printf "%s" $path) }}
   {{/*

--- a/layouts/shortcodes/screenshot.html
+++ b/layouts/shortcodes/screenshot.html
@@ -1,1 +1,72 @@
-image.html
+<!--
+Short code to add an image to the page inside a card with an optional caption
+Usage:
+image filename dimension
+e.g.:
+image example.svg 200x - Sizes image to width 200
+image example.svg x200 - Sizes image to height 200
+
+Caption is taken from the short code content
+-->
+
+{{/*
+Page resources
+</br>
+{{ range .Page.Resources }}
+{{ printf "%s" .RelPermalink }}
+</br>
+{{ end }}
+*/}}
+
+{{/* First try to get the resource from the page resources */}}
+{{ $image := .Page.Resources.GetMatch (printf "%s" (.Get 0)) }}
+{{ if not $image }}
+  {{/* Image not in the page resources, so get from global assets/images */}}
+  {{ $path := printf "images/%s" (.Get 0) }}
+  {{/* printf "path: [%s]" $path */}}
+  {{ $image = resources.Get (printf "%s" $path) }}
+  {{/*
+  {{ printf "Asset RelPermalink: [%s]" $image.RelPermalink }}
+  */}}
+{{ end }}
+
+{{ $param1 := .Get 1 }}
+{{ $width := 0 }}
+{{ $height := 0 }}
+{{ $hasSize := false }}
+{{ if not $param1 }}
+  {{ $hasSize = false }}
+{{ else if hasPrefix $param1 "x" }}
+  {{ $height = int (strings.TrimPrefix "x" $param1) }}
+  {{ $hasSize = true }}
+{{ else }}
+  {{ $width = int (strings.TrimSuffix "x" $param1) }}
+  {{ $hasSize = true }}
+{{ end }}
+
+{{ if not $hasSize }}
+<div class="card rounded shadow-stroom p-2 td-post-card mb-4 mt-4" style="width: fit-content;">
+{{ else if gt $width 0 }}
+<div class="card rounded shadow-stroom p-2 td-post-card mb-4 mt-4" style="max-width: {{ add $width 10 }}px">
+{{ else }}
+<div class="card rounded shadow-stroom p-2 td-post-card mb-4 mt-4" >
+{{ end }}
+  <a title="{{ $image.Name }}" href="{{ $image.RelPermalink }}">
+    <figure style="margin-block-end: 0px" >
+      {{ if not $hasSize }}
+      <img class="card-img-top" src="{{ $image.RelPermalink }}" style="max-width: fit-content" alt="{{ $image.Name }}">
+      {{ else if $width }}
+      <img class="card-img-top" src="{{ $image.RelPermalink }}" style="max-width:{{ $width }}" alt="{{ $image.Name }}">
+      {{ else }}
+      <img class="card-img-top" src="{{ $image.RelPermalink }}" style="max-height:{{ $height }}" alt="{{ $image.Name }}">
+      {{ end }}
+
+      {{ with .Inner }}
+      <div class="card-body px-0 pt-2 pb-0">
+        <hr style="border-top: 1px solid #ddd; margin-top: 0px; margin-bottom:4px;">
+        <figcaption class="card-text" style="font-size: smaller; text-align: center;">{{ . }}{{ with $image.Params.byline }}<span class="text-muted" style="font-size: smaller"><br/>{{ . | html }}</span>{{ end }}</figcaption>
+      </div>
+      {{ end }}
+    </figure>
+  </a>
+</div>

--- a/layouts/shortcodes/stroom-icons-gallery.html
+++ b/layouts/shortcodes/stroom-icons-gallery.html
@@ -6,8 +6,9 @@ Short code to display all stroom icons
 {{ with resources.Match (printf "%s*" $pathPrefix) }}
   <div class="row bg-light stroom-icon-gallery">
   {{ range . }}
-    {{ $filename := strings.TrimPrefix $pathPrefix .Name }}
-    {{ $rel_path := strings.TrimPrefix "images/stroom-ui" .Name }}
+    {{ $resourceName := strings.TrimPrefix "/" .Name }}
+    {{ $filename := strings.TrimPrefix $pathPrefix $resourceName }}
+    {{ $rel_path := strings.TrimPrefix "images/stroom-ui/" $resourceName }}
     {{ if and
     (not (or
       (eq $filename "tabBackground.png")


### PR DESCRIPTION
Fixes #115.

Upgrade Docsy from 0.6.0 to 0.10.0 and the Hugo build image to 0.125.4, then enable Docsy's light/dark/automatic colour-mode selector. Refresh the local scripts override for Bootstrap 5.3 while retaining offline Lunr support, and update the local image/shortcode compatibility needed by the newer Hugo resource handling.

Validation:
- production Hugo build succeeds after the normal PlantUML generation step: 742 pages
- generated navbar contains light, dark and automatic theme options
- generated JS includes persisted colour-theme handling
- `go mod verify` passes
- `git diff --check` passes