### PR TITLE
Fix Kubernetes configure link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ are not recorded in here. Changes are in chronological order with the most
 recent at the top.
 
 
+* Fix broken Kubernetes install guide link to the Stroom cluster configuration page.
+
 * Add `Analytic Rules` user guide section covering queries, execution schedules, notifications, detections, duplicate management, streaming and table builder.
 
 * Add `Reports` user guide section covering report settings, file types, AI summaries and delivery.

--- a/content/en/docs/install-guide/kubernetes/configure-database-server.md
+++ b/content/en/docs/install-guide/kubernetes/configure-database-server.md
@@ -107,4 +107,4 @@ Upgrading or removing a `DatabaseServer` requires the `StroomCluster` be [remove
 
 ## Next Steps
 
-[Configure](configure-stroom-cluster.md) a Stroom cluster
+[Configure]({{< relref "configure-stroom-cluster" >}}) a Stroom cluster


### PR DESCRIPTION
Fixes #116.

Replace the broken relative Markdown link in the Kubernetes database-server guide with Hugo's `relref` shortcode, matching the surrounding Kubernetes documentation and avoiding the erroneous nested URL.

Also adds the required changelog entry.

Validation:
- Documentation style check passed for the changed page.
- `git diff --check` passed.
