### PR TITLE
Link to DataFeedClient source

### DIFF
--- a/content/en/docs/sending-data/example-clients/simple-java-client.md
+++ b/content/en/docs/sending-data/example-clients/simple-java-client.md
@@ -9,7 +9,7 @@ description: >
 
 ---
 
-The `stroom-java-client` provides an example Java client that can:
+The {{< external-link "DataFeedClient" "https://github.com/gchq/stroom-clients/blob/master/java/src/main/java/stroom/clients/DataFeedClient.java" >}} provides an example Java client that can:
 
 * Read a zip, gzip or uncompressed an input file.
 * Perform a HTTP post of data with zip, gzip or uncompressed compression.


### PR DESCRIPTION
Fixes #72.

Link the Simple Java Client documentation directly to the current `DataFeedClient.java` source in `gchq/stroom-clients`, so readers can get the code before following the compile and usage examples.

Validation:
- `./check_style.sh content/en/docs/sending-data/example-clients/simple-java-client.md`
- `git diff --check`
