### PR TITLE
Add Markdown linting to CI

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,43 @@
+config:
+  default: true
+  # Existing documentation predates Markdownlint. Keep the checks that are
+  # currently clean enabled, and leave legacy formatting rules to the existing
+  # style checker until the content is brought into compliance.
+  MD001: false
+  MD003: false
+  MD004: false
+  MD005: false
+  MD007: false
+  MD009: false
+  MD010: false
+  MD011: false
+  MD012: false
+  MD013: false
+  MD022: false
+  MD024: false
+  MD025: false
+  MD026: false
+  MD027: false
+  MD031: false
+  MD032: false
+  MD033: false
+  MD034: false
+  MD036: false
+  MD037: false
+  MD038: false
+  MD040: false
+  MD041: false
+  MD045: false
+  MD047: false
+  MD049: false
+  MD050: false
+  MD051: false
+  MD055: false
+  MD056: false
+  MD058: false
+  MD059: false
+  MD060: false
+
+globs:
+  - "*.md"
+  - "content/**/*.md"

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -222,6 +222,13 @@ build_version_from_source() {
   # Do the spelling/link checking before we build the site so we
   # can fail faster
 
+  if [[ -f ./.markdownlint-cli2.yaml ]]; then
+    echo "::group::Checking Markdown"
+    echo -e "${GREEN}Checking Markdown structure${NC}"
+    npx --yes markdownlint-cli2@0.23.2
+    echo "::endgroup::"
+  fi
+
   echo "::group::Checking for broken links"
   echo -e "${GREEN}Checking all .md files for broken links${NC}"
   ./broken_links.sh


### PR DESCRIPTION
Fixes #60.

Add Markdownlint to the CI build with the rules that are clean on the existing documentation tree enabled. Legacy formatting rules with pre-existing violations remain deferred to the current style checker, so new structural problems can be caught without requiring an unrelated documentation rewrite.

Validation:
- Markdownlint: 484 files, 0 issues
- negative regression: a temporary empty link is rejected with MD042
- `shellcheck ci_build.sh`
- `git diff --check`
